### PR TITLE
commentsテーブルのpost idにインデックスをつけた

### DIFF
--- a/sql/query.sql
+++ b/sql/query.sql
@@ -2,4 +2,4 @@
 
 USE isuconp;
 
-ALTER TABLE `comments` ADD INDEX `post_id_idx` (`post_id`);
+CREATE INDEX IF NOT EXISTS `post_id_idx` ON `comments` (`post_id`);

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -1,0 +1,5 @@
+-- 2025-08-12 #4
+
+USE isuconp;
+
+ALTER TABLE `comments` ADD INDEX `post_id_idx` (`post_id`);

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -4,10 +4,11 @@ FROM ubuntu:latest
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl && \
+        curl \
         default-mysql-client \
         git \
         percona-toolkit \
+        vim && \
     rm -rf /var/lib/apt/lists/*
 
 # Install alp


### PR DESCRIPTION
## 関連Issue

- Close #4 

## 目的

最も長かったクエリ

```
# Query 1: 6.94 QPS, 10.65x concurrency, ID 0x624863D30DAC59FA16849282195BE09F at byte 913204
# This item is included in the report because it matches --limit.
# Scores: V/M = 1.69
# Time range: 2025-08-12T07:58:13 to 2025-08-12T07:58:44
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          5     215
# Exec time     66    330s    18ms      7s      2s      5s      2s   672ms
# Lock time     17   587us       0    14us     2us     5us     2us     2us
# Rows sent      0     570       0       3    2.65    2.90    0.93    2.90
# Rows examine  46  20.50M  97.66k  97.66k  97.66k  97.04k       0  97.04k
# Query size    11  17.26k      81      83   82.20   80.10       0   80.10
# String:
# Databases    isuconp
# Hosts        172.18.0.5
# Users        root
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ##############################
# 100ms  ###############################################################
#    1s  ################################################################
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
#    SHOW CREATE TABLE `isuconp`.`comments`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3\G
```

`comments` のテーブルで特定の行を探すために大量の行を走査していることがわかる．
⇒ `post_id` のようなprimary keyでない情報を検索条件に置くと索引がないので全探索が行われる
⇒ `post_id` のインデックスを追加する．

## やったこと

```
mysql > ALTER TABLE `comments` ADD INDEX `post_id_idx` (`post_id`);
```

## 測定結果

合計時間が499s ⇒47sまで改善されている

- 改善前

```bash
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time           499s     1us      7s   126ms   580ms   558ms    31us
# Lock time            3ms       0    52us       0     4us     2us       0
# Rows sent        275.16k       0   9.77k   71.08    2.90  800.04       0
# Rows examine      43.90M       0  97.67k  11.34k  97.04k  30.89k       0
# Query size       148.55k       8     216   38.38   80.10   15.47   31.70
```

- 改善後

```bash
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time            47s     1us   690ms   601us   424us     8ms   113us
# Lock time          170ms       0    82ms     2us     4us   279us       0
# Rows sent          1.53M       0   9.78k   20.33    0.99  426.08       0
# Rows examine       7.31M       0  97.67k   97.29   10.84   2.29k       0
# Query size         8.29M       8   1.02M  110.41   76.28   7.68k   31.70
```

Query1を見ると内容が変わっている．

```bash
# Query 1: 4.30 QPS, 0.57x concurrency, ID 0x4858CF4D8CAA743E839C127C71B69E75 at byte 10501727
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.08
# Time range: 2025-08-12T09:45:25 to 2025-08-12T09:45:55
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0     129
# Exec time     36     17s     7ms   633ms   133ms   323ms   104ms   105ms
# Lock time      0   568us     1us    53us     4us     5us     5us     3us
# Rows sent     80   1.23M   9.77k   9.78k   9.77k   9.33k       0   9.33k
# Rows examine  33   2.46M  19.54k  19.56k  19.55k  19.40k       0  19.40k
# Query size     0  11.59k      92      92      92      92       0      92
# String:
# Databases    isuconp
# Hosts        172.18.0.5
# Users        root
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  #
#  10ms  #################################
# 100ms  ################################################################
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `isuconp` LIKE 'posts'\G
#    SHOW CREATE TABLE `isuconp`.`posts`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` ORDER BY `created_at` DESC\G
```

